### PR TITLE
Reduce all interfaces to a single method

### DIFF
--- a/src/ServerRequestFactoryInterface.php
+++ b/src/ServerRequestFactoryInterface.php
@@ -16,11 +16,4 @@ interface ServerRequestFactoryInterface
      * @return ServerRequestInterface
      */
     public function createServerRequest($method, $uri);
-
-    /**
-     * Create a new server request from PHP globals.
-     *
-     * @return ServerRequestInterface
-     */
-    public function createServerRequestFromGlobals();
 }

--- a/src/ServerRequestFromGlobalsFactoryInterface.php
+++ b/src/ServerRequestFromGlobalsFactoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Psr\Http\Factory;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+interface ServerRequestFromGlobalsFactoryInterface
+{
+    /**
+     * Create a new server request from PHP globals.
+     *
+     * @return ServerRequestInterface
+     */
+    public function createServerRequestFromGlobals();
+}

--- a/src/StreamFactoryInterface.php
+++ b/src/StreamFactoryInterface.php
@@ -7,46 +7,13 @@ use Psr\Http\Message\StreamInterface;
 interface StreamFactoryInterface
 {
     /**
-     * Create a new stream with no content.
-     *
-     * The stream will be writable and seekable.
-     *
-     * @return StreamInterface
-     */
-    public function createStream();
-
-    /**
-     * Create a new stream from a callback.
-     *
-     * The stream will be read-only and not seekable.
-     *
-     * @param callable $callback
-     *
-     * @return StreamInterface
-     */
-    public function createStreamFromCallback(callable $callback);
-
-    /**
      * Create a new stream from a resource.
      *
-     * @param resource $body
+     * The resource MUST be readable and SHOULD be seekable. It MAY be writable.
      *
-     * @return StreamInterface
-     *
-     * @throws \InvalidArgumentException
-     *  If a passed resource is not readable.
-     */
-    public function createStreamFromResource($body);
-
-    /**
-     * Create a new stream from a string.
-     *
-     * A temporary resource will be created with the content of the string.
-     * The resource will be writable and seekable.
-     *
-     * @param string $body
+     * @param resource $resource
      *
      * @return StreamInterface
      */
-    public function createStreamFromString($body);
+    public function createStream($resource);
 }


### PR DESCRIPTION
Each method is a different use case and would rarely, if ever, be used
in the same class. In the case of streams, not all stream types are
supported by the various PSR-7 implementations.

Refs #1
Refs https://github.com/php-fig/fig-standards/pull/759#issuecomment-238969730
