### PR TITLE
Add separate methods for creating streams

### DIFF
--- a/src/StreamFactoryInterface.php
+++ b/src/StreamFactoryInterface.php
@@ -7,17 +7,37 @@ use Psr\Http\Message\StreamInterface;
 interface StreamFactoryInterface
 {
     /**
-     * Create a new stream from a resource or a string.
+     * Create a new stream from a string.
      *
-     * If the argument is a resource, it MUST be readable and SHOULD be seekable. It MAY be writable.
-     * If the argument is a string, a temporary resource will be created that is writable and seekable.
-     * 
-     * If the arugment is a string it will be interpided as the content of the stream. File names or 
-     * file paths are not supported. 
+     * The stream SHOULD be created with a temporary resource.
      *
-     * @param string|resource $resource
+     * @param string $content
      *
      * @return StreamInterface
      */
-    public function createStream($resource);
+    public function createStream($content = '');
+
+    /**
+     * Create a stream from an existing file.
+     *
+     * The file MUST be opened using the given mode, which may be any mode
+     * supported by the `fopen` function.
+     *
+     * @param string $file
+     * @param string $mode
+     *
+     * @return StreamInterface
+     */
+    public function createStreamFromFile($file, $mode = 'r');
+
+    /**
+     * Create a new stream from an existing resource.
+     *
+     * The stream MUST be readable and may be writable.
+     *
+     * @param resource $resource
+     *
+     * @return StreamInterface
+     */
+    public function createStreamFromResource($resource);
 }


### PR DESCRIPTION
Being able to create streams from 3 distinct sources aligns with
existing middleware that may need to:

- Create streams from strings
- Create streams from files
- Create streams from resources

In the case of strings and files, the final result will be a resource
that will be attached to the stream.

Refs #2
Refs #4
Refs #14
Refs #16