### PR TITLE
Docblock update

### DIFF
--- a/src/StreamFactoryInterface.php
+++ b/src/StreamFactoryInterface.php
@@ -28,6 +28,9 @@ interface StreamFactoryInterface
      * @param string $filename
      * @param string $mode
      *
+     * @throws \InvalidArgumentException
+     *  If the file cannot be opened using the mode requested.
+     *
      * @return StreamInterface
      */
     public function createStreamFromFile($filename, $mode = 'r');


### PR DESCRIPTION
Method `createStreamFromFile()` throws `\InvalidArgumentException`

Closes #28