### PR TITLE
Make createResponse consistent with withStatus

### DIFF
--- a/src/ResponseFactoryInterface.php
+++ b/src/ResponseFactoryInterface.php
@@ -9,8 +9,10 @@ interface ResponseFactoryInterface
     /**
      * Create a new response.
      *
-     * @param integer $code HTTP status code
-     * @param string $reasonPhrase HTTP reason phrase
+     * @param int $code The 3-digit integer result code to set.
+     * @param string $reasonPhrase The reason phrase to use with the
+     *     provided status code; if none is provided, implementations MAY
+     *     use the defaults as suggested in the HTTP specification.
      *
      * @return ResponseInterface
      */

--- a/src/ResponseFactoryInterface.php
+++ b/src/ResponseFactoryInterface.php
@@ -10,8 +10,9 @@ interface ResponseFactoryInterface
      * Create a new response.
      *
      * @param integer $code HTTP status code
+     * @param string $reasonPhrase HTTP reason phrase
      *
      * @return ResponseInterface
      */
-    public function createResponse($code = 200);
+    public function createResponse($code = 200, $reasonPhrase = '');
 }


### PR DESCRIPTION
To resolve #37. I think making the PSR-17 `createResponse` match the PSR-7 `withStatus` just makes sense. Would sadden me to see this fall by the wayside.