### PR TITLE
Sync interfaces to proposed changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.0.0",
         "psr/http-message": "^1.0"
     },
     "autoload": {

--- a/src/RequestFactoryInterface.php
+++ b/src/RequestFactoryInterface.php
@@ -5,15 +5,19 @@ namespace Interop\Http\Factory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 
-interface RequestFactoryInterface
+interface RequestFactoryInterface extends
+    StreamFactoryInterface,
+    UriFactoryInterface
 {
     /**
      * Create a new request.
      *
-     * @param string $method
-     * @param UriInterface|string $uri
+     * @param string $method The HTTP method associated with the request.
+     * @param UriInterface|string $uri The URI associated with the request. If
+     *     the value is a string, the factory MUST create a UriInterface
+     *     instance based on it.
      *
      * @return RequestInterface
      */
-    public function createRequest($method, $uri);
+    public function createRequest(string $method, $uri): RequestInterface;
 }

--- a/src/ResponseFactoryInterface.php
+++ b/src/ResponseFactoryInterface.php
@@ -4,14 +4,17 @@ namespace Interop\Http\Factory;
 
 use Psr\Http\Message\ResponseInterface;
 
-interface ResponseFactoryInterface
+interface ResponseFactoryInterface extends StreamFactoryInterface
 {
     /**
      * Create a new response.
      *
-     * @param integer $code HTTP status code
+     * @param int $code HTTP status code; defaults to 200
+     * @param string $reasonPhrase Reason phrase to associate with status code
+     *     in generated response; if none is provided implementations MAY use
+     *     the defaults as suggested in the HTTP specification.
      *
      * @return ResponseInterface
      */
-    public function createResponse($code = 200);
+    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface;
 }

--- a/src/ServerRequestFactoryInterface.php
+++ b/src/ServerRequestFactoryInterface.php
@@ -5,27 +5,22 @@ namespace Interop\Http\Factory;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 
-interface ServerRequestFactoryInterface
+interface ServerRequestFactoryInterface extends
+    StreamFactoryInterface,
+    UploadedFileFactoryInterface,
+    UriFactoryInterface
 {
     /**
      * Create a new server request.
      *
-     * @param string $method
-     * @param UriInterface|string $uri
+     * @param string $method The HTTP method associated with the request.
+     * @param UriInterface|string $uri The URI associated with the request. If
+     *     the value is a string, the factory MUST create a UriInterface
+     *     instance based on it.
+     * @param array $serverParams Array of SAPI parameters with which to seed
+     *     the generated request instance.
      *
      * @return ServerRequestInterface
      */
-    public function createServerRequest($method, $uri);
-
-    /**
-     * Create a new server request from server variables.
-     *
-     * @param array $server Typically $_SERVER or similar structure.
-     *
-     * @return ServerRequestInterface
-     *
-     * @throws \InvalidArgumentException
-     *  If no valid method or URI can be determined.
-     */
-    public function createServerRequestFromArray(array $server);
+    public function createServerRequest(string $method, $uri, array $serverParams = []): ServerRequestInterface;
 }

--- a/src/StreamFactoryInterface.php
+++ b/src/StreamFactoryInterface.php
@@ -11,11 +11,11 @@ interface StreamFactoryInterface
      *
      * The stream SHOULD be created with a temporary resource.
      *
-     * @param string $content
+     * @param string $content String content with which to populate the stream.
      *
      * @return StreamInterface
      */
-    public function createStream($content = '');
+    public function createStream(string $content = ''): StreamInterface;
 
     /**
      * Create a stream from an existing file.
@@ -25,24 +25,21 @@ interface StreamFactoryInterface
      *
      * The `$filename` MAY be any string supported by `fopen()`.
      *
-     * @param string $filename
-     * @param string $mode
-     *
-     * @throws \InvalidArgumentException
-     *  If the file cannot be opened using the mode requested.
+     * @param string $filename Filename or stream URI to use as basis of stream.
+     * @param string $mode Mode with which to open the underlying filename/stream.
      *
      * @return StreamInterface
      */
-    public function createStreamFromFile($filename, $mode = 'r');
+    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface;
 
     /**
      * Create a new stream from an existing resource.
      *
      * The stream MUST be readable and may be writable.
      *
-     * @param resource $resource
+     * @param resource $resource PHP resource to use as basis of stream.
      *
      * @return StreamInterface
      */
-    public function createStreamFromResource($resource);
+    public function createStreamFromResource($resource): StreamInterface;
 }

--- a/src/UploadedFileFactoryInterface.php
+++ b/src/UploadedFileFactoryInterface.php
@@ -18,22 +18,22 @@ interface UploadedFileFactoryInterface
      * @see http://php.net/manual/features.file-upload.post-method.php
      * @see http://php.net/manual/features.file-upload.errors.php
      *
-     * @param string|resource $file
-     * @param integer $size in bytes
-     * @param integer $error PHP file upload error
-     * @param string $clientFilename
-     * @param string $clientMediaType
+     * @param string|resource|StreamInterface $file Underlying file, PHP stream
+     *     resource, or StreamInterface representing the uploaded file content.
+     * @param int $size in bytes
+     * @param int $error PHP file upload error
+     * @param string $clientFilename Filename as provided by the client, if any.
+     * @param string $clientMediaType Media type as provided by the client, if any.
      *
      * @return UploadedFileInterface
      *
-     * @throws \InvalidArgumentException
-     *  If the file resource is not readable.
+     * @throws \InvalidArgumentException If the file resource is not readable.
      */
     public function createUploadedFile(
         $file,
-        $size = null,
-        $error = \UPLOAD_ERR_OK,
-        $clientFilename = null,
-        $clientMediaType = null
-    );
+        int $size = null,
+        int $error = \UPLOAD_ERR_OK,
+        string $clientFilename = null,
+        string $clientMediaType = null
+    ): UploadedFileInterface;
 }

--- a/src/UploadedFileFactoryInterface.php
+++ b/src/UploadedFileFactoryInterface.php
@@ -2,15 +2,13 @@
 
 namespace Interop\Http\Factory;
 
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
-interface UploadedFileFactoryInterface
+interface UploadedFileFactoryInterface extends StreamFactoryInterface
 {
     /**
      * Create a new uploaded file.
-     *
-     * If a string is used to create the file, a temporary resource will be
-     * created with the content of the string.
      *
      * If a size is not provided it will be determined by checking the size of
      * the file.
@@ -18,8 +16,8 @@ interface UploadedFileFactoryInterface
      * @see http://php.net/manual/features.file-upload.post-method.php
      * @see http://php.net/manual/features.file-upload.errors.php
      *
-     * @param string|resource|StreamInterface $file Underlying file, PHP stream
-     *     resource, or StreamInterface representing the uploaded file content.
+     * @param StreamInterface $stream Underlying stream representing the
+     *     uploaded file content.
      * @param int $size in bytes
      * @param int $error PHP file upload error
      * @param string $clientFilename Filename as provided by the client, if any.
@@ -30,7 +28,7 @@ interface UploadedFileFactoryInterface
      * @throws \InvalidArgumentException If the file resource is not readable.
      */
     public function createUploadedFile(
-        $file,
+        StreamInterface $stream,
         int $size = null,
         int $error = \UPLOAD_ERR_OK,
         string $clientFilename = null,

--- a/src/UriFactoryInterface.php
+++ b/src/UriFactoryInterface.php
@@ -13,8 +13,7 @@ interface UriFactoryInterface
      *
      * @return UriInterface
      *
-     * @throws \InvalidArgumentException
-     *  If the given URI cannot be parsed.
+     * @throws \InvalidArgumentException If the given URI cannot be parsed.
      */
-    public function createUri($uri = '');
+    public function createUri(string $uri = ''): UriInterface;
 }


### PR DESCRIPTION
This patch syncs the interfaces to those as proposed in php-fig/fig-standards#1022; the changes represent a BC break.

Changes include:

- Adoption of PHP 7 as the minimum supported version, in order to provide scalar type hints for arguments as required, and return type hints for all factory methods.
- `ResponseFactoryInterface::createResponse()` now defines an optional second argument, `string $reasonPhrase`.
- `ServerRequestFactoryInterface::createServerRequest()` now defines an optional third argument, `array $serverParams`.
- Removes `ServerRequestFactoryInterface::createServerRequestFromArray()`.
- `ResponseFactoryInterface` and `UploadedFileFactoryInterface` now extend `StreamFactoryInterface`.
- `RequestFactoryInterface` now extends `UriFactoryInterface` and `StreamFactoryInterface`.
- `ServerRequestFactoryInterface` now extends `UriFactoryInterface`, `StreamFactoryInterface`, and `UploadedFileFactoryInterface`.

The patch also updates all docblocks to match those in the proposed patch to the specification.

This patch SHOULD NOT be merged until the related patch on fig-standards is merged, to ensure it remains synchronized with any changes.