### PR TITLE
Remove inheritance from all interfaces

### DIFF
--- a/src/RequestFactoryInterface.php
+++ b/src/RequestFactoryInterface.php
@@ -5,9 +5,7 @@ namespace Interop\Http\Factory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 
-interface RequestFactoryInterface extends
-    StreamFactoryInterface,
-    UriFactoryInterface
+interface RequestFactoryInterface
 {
     /**
      * Create a new request.

--- a/src/ResponseFactoryInterface.php
+++ b/src/ResponseFactoryInterface.php
@@ -4,7 +4,7 @@ namespace Interop\Http\Factory;
 
 use Psr\Http\Message\ResponseInterface;
 
-interface ResponseFactoryInterface extends StreamFactoryInterface
+interface ResponseFactoryInterface
 {
     /**
      * Create a new response.

--- a/src/ServerRequestFactoryInterface.php
+++ b/src/ServerRequestFactoryInterface.php
@@ -5,10 +5,7 @@ namespace Interop\Http\Factory;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 
-interface ServerRequestFactoryInterface extends
-    StreamFactoryInterface,
-    UploadedFileFactoryInterface,
-    UriFactoryInterface
+interface ServerRequestFactoryInterface
 {
     /**
      * Create a new server request.

--- a/src/UploadedFileFactoryInterface.php
+++ b/src/UploadedFileFactoryInterface.php
@@ -5,7 +5,7 @@ namespace Interop\Http\Factory;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
-interface UploadedFileFactoryInterface extends StreamFactoryInterface
+interface UploadedFileFactoryInterface
 {
     /**
      * Create a new uploaded file.


### PR DESCRIPTION
Based on discussions within the working group, this patch removes inheritance from all proposed interfaces.

We may create union types in the future (interfaces that extend multiple interfaces in order to provide a single type with factory methods for all collaborators), but for now, consensus is that the base interfaces should not do so.