### PR TITLE
Extend interfaces from psr/http-factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
+        "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0"
     },
     "autoload": {

--- a/src/RequestFactoryInterface.php
+++ b/src/RequestFactoryInterface.php
@@ -2,20 +2,8 @@
 
 namespace Interop\Http\Factory;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\UriInterface;
+use Psr\Http\Message\RequestFactoryInterface as PsrRequestFactoryInterface;
 
-interface RequestFactoryInterface
+interface RequestFactoryInterface extends PsrRequestFactoryInterface
 {
-    /**
-     * Create a new request.
-     *
-     * @param string $method The HTTP method associated with the request.
-     * @param UriInterface|string $uri The URI associated with the request. If
-     *     the value is a string, the factory MUST create a UriInterface
-     *     instance based on it.
-     *
-     * @return RequestInterface
-     */
-    public function createRequest(string $method, $uri): RequestInterface;
 }

--- a/src/ResponseFactoryInterface.php
+++ b/src/ResponseFactoryInterface.php
@@ -2,19 +2,8 @@
 
 namespace Interop\Http\Factory;
 
-use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ResponseFactoryInterface as PsrResponseFactoryInterface;
 
-interface ResponseFactoryInterface
+interface ResponseFactoryInterface extends PsrResponseFactoryInterface
 {
-    /**
-     * Create a new response.
-     *
-     * @param int $code HTTP status code; defaults to 200
-     * @param string $reasonPhrase Reason phrase to associate with status code
-     *     in generated response; if none is provided implementations MAY use
-     *     the defaults as suggested in the HTTP specification.
-     *
-     * @return ResponseInterface
-     */
-    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface;
 }

--- a/src/ServerRequestFactoryInterface.php
+++ b/src/ServerRequestFactoryInterface.php
@@ -2,26 +2,8 @@
 
 namespace Interop\Http\Factory;
 
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\UriInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface as PsrServerRequestFactoryInterface;
 
-interface ServerRequestFactoryInterface
+interface ServerRequestFactoryInterface extends PsrServerRequestFactoryInterface
 {
-    /**
-     * Create a new server request.
-     *
-     * Note that server-params are taken precisely as given - no parsing/processing
-     * of the given values is performed, and, in particular, no attempt is made to
-     * determine the HTTP method or URI, which must be provided explicitly.
-     *
-     * @param string $method The HTTP method associated with the request.
-     * @param UriInterface|string $uri The URI associated with the request. If
-     *     the value is a string, the factory MUST create a UriInterface
-     *     instance based on it.
-     * @param array $serverParams Array of SAPI parameters with which to seed
-     *     the generated request instance.
-     *
-     * @return ServerRequestInterface
-     */
-    public function createServerRequest(string $method, $uri, array $serverParams = []): ServerRequestInterface;
 }

--- a/src/StreamFactoryInterface.php
+++ b/src/StreamFactoryInterface.php
@@ -2,44 +2,8 @@
 
 namespace Interop\Http\Factory;
 
-use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\StreamFactoryInterface as PsrStreamFactoryInterface;
 
-interface StreamFactoryInterface
+interface StreamFactoryInterface extends PsrStreamFactoryInterface
 {
-    /**
-     * Create a new stream from a string.
-     *
-     * The stream SHOULD be created with a temporary resource.
-     *
-     * @param string $content String content with which to populate the stream.
-     *
-     * @return StreamInterface
-     */
-    public function createStream(string $content = ''): StreamInterface;
-
-    /**
-     * Create a stream from an existing file.
-     *
-     * The file MUST be opened using the given mode, which may be any mode
-     * supported by the `fopen` function.
-     *
-     * The `$filename` MAY be any string supported by `fopen()`.
-     *
-     * @param string $filename Filename or stream URI to use as basis of stream.
-     * @param string $mode Mode with which to open the underlying filename/stream.
-     *
-     * @return StreamInterface
-     */
-    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface;
-
-    /**
-     * Create a new stream from an existing resource.
-     *
-     * The stream MUST be readable and may be writable.
-     *
-     * @param resource $resource PHP resource to use as basis of stream.
-     *
-     * @return StreamInterface
-     */
-    public function createStreamFromResource($resource): StreamInterface;
 }

--- a/src/UploadedFileFactoryInterface.php
+++ b/src/UploadedFileFactoryInterface.php
@@ -2,36 +2,8 @@
 
 namespace Interop\Http\Factory;
 
-use Psr\Http\Message\StreamInterface;
-use Psr\Http\Message\UploadedFileInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface as PsrUploadedFileFactoryInterface;
 
-interface UploadedFileFactoryInterface
+interface UploadedFileFactoryInterface extends PsrUploadedFileFactoryInterface
 {
-    /**
-     * Create a new uploaded file.
-     *
-     * If a size is not provided it will be determined by checking the size of
-     * the file.
-     *
-     * @see http://php.net/manual/features.file-upload.post-method.php
-     * @see http://php.net/manual/features.file-upload.errors.php
-     *
-     * @param StreamInterface $stream Underlying stream representing the
-     *     uploaded file content.
-     * @param int $size in bytes
-     * @param int $error PHP file upload error
-     * @param string $clientFilename Filename as provided by the client, if any.
-     * @param string $clientMediaType Media type as provided by the client, if any.
-     *
-     * @return UploadedFileInterface
-     *
-     * @throws \InvalidArgumentException If the file resource is not readable.
-     */
-    public function createUploadedFile(
-        StreamInterface $stream,
-        int $size = null,
-        int $error = \UPLOAD_ERR_OK,
-        string $clientFilename = null,
-        string $clientMediaType = null
-    ): UploadedFileInterface;
 }

--- a/src/UriFactoryInterface.php
+++ b/src/UriFactoryInterface.php
@@ -2,18 +2,8 @@
 
 namespace Interop\Http\Factory;
 
-use Psr\Http\Message\UriInterface;
+use Psr\Http\Message\UriFactoryInterface as PsrUriFactoryInterface;
 
 interface UriFactoryInterface
 {
-    /**
-     * Create a new URI.
-     *
-     * @param string $uri
-     *
-     * @return UriInterface
-     *
-     * @throws \InvalidArgumentException If the given URI cannot be parsed.
-     */
-    public function createUri(string $uri = ''): UriInterface;
 }


### PR DESCRIPTION
Now that PSR-17 is accepted, we can mark this package deprecated, and do a new minor release that has all interfaces extend those from the official specification.